### PR TITLE
Changing to correct trace function invocaton

### DIFF
--- a/src/pairwise/gppwInf.m
+++ b/src/pairwise/gppwInf.m
@@ -82,7 +82,7 @@ if nargout >= 2
     dKdi = dprefKernel(Xleft,Xleft,i) + dprefKernel(Xright,Xright,i);
     dKpmi = dprefKernel(Xleft,Xright,i);
     dKdi = dKdi - dKpmi - dKpmi';
-    grad.hyp(i) = 0.5 * traceAB(invKyMinusAlpha2,dKdi);
+    grad.hyp(i) = 0.5 * traceABsym(invKyMinusAlpha2,dKdi);
   end
   
   % gradients of noise


### PR DESCRIPTION
With out correction running point-wise example:

``` mathlab
addpath(genpath('src/'))
addpath(genpath('libs/'))
source('src/scripts/demo_gppw.m')
```

will result ending with error message:

```
error: 'traceAB' undefined near line 85 column 25
error: called from:
error:   /Users/bartlomiej.twardowsk/Development/github/gpfm-master/src/pairwise/gppwInf.m at line 85, column 17
error:   /Users/bartlomiej.twardowsk/Development/github/gpfm-master/src/pairwise/gppwSgdLearn.m at line 40, column 16
error:   /Users/bartlomiej.twardowsk/Development/github/gpfm-master/src/scripts/demo_gppw.m at line 33, column 7
```
